### PR TITLE
Magic Woman - Part 3 Postmortem

### DIFF
--- a/Elden Ring/Magic Woman.md
+++ b/Elden Ring/Magic Woman.md
@@ -2,20 +2,21 @@
 
 ## Basis
 
-[Melee Mage](https://www.youtube.com/watch?v=NXQXAGWjyh4)
-
 [Astrologer](https://www.youtube.com/watch?v=ISLC9b7YLsg&)
+
+[Prisoner](https://www.youtube.com/watch?v=k3TFfIzbN8I)
+
+[Melee Mage](https://www.youtube.com/watch?v=NXQXAGWjyh4)
 
 [Spellblade (Early Game)](https://www.youtube.com/watch?v=OCDBjAPCepw)
 
 [Spellblade (Late Game)](https://www.youtube.com/watch?v=ng6NTaP4fPs)
 
-[Prisoner](https://www.youtube.com/watch?v=k3TFfIzbN8I)
-
 [ALL Sorcery Spells in Elden Ring](https://www.youtube.com/watch?v=gqSzUthyrsU)
 
+
 - This build will be a mixture of melee and long range magical spells, mostly the Carian Glintstone schools and the Carian Weapon Spells.  
-- Dagger is for buffing range spells with Determination.
+- Dagger is for buffing range spells with Determination and for cheeky counters/backstabs.
 - Ranged spells are big hitters by and large.  
 - Stay out of melee expect when pushed, then switch to Slicer/Greatsword or a cheeky back stab/counter if able.
 
@@ -32,71 +33,74 @@ Intelligence|26,52,80
 Faith|base
 Arcane|base
 
-*soft cap Mind (55/60), Vigor (40/60).
-*Focus on Intelligence (20/50/80)
-*Endurance (15/30/50) should be in line for mid rolls.
+- **Soft Caps** Mind (55/60), Vigor (40/60), Intelligence (20/50/80), Endurance (15/30/50).
+- Focus on increasing Mind and Intelligence as needed.
+- Endurance should be in line for mid rolls.
+
 
 ## Weapons / Gear
 
 ### Staff (Weapon Icon)
 
 - [Carian Regal Scepter](https://eldenring.wiki.fextralife.com/Carian+Regal+Scepter)
-  - Location:Obtained when unlocking the Remembrance of The Full Moon Queen's power by handing it over to Enia at Roundtable Hold.
+  - **Location:** Obtained when unlocking the Remembrance of The Full Moon Queen's power by handing it over to Enia at Roundtable Hold.
   - The second-most powerful staff, and the most powerful non-fp-cost-increasing staff, for players with 69 intelligence or above.
 - [Lusat's Glintstone Staff](https://eldenring.wiki.fextralife.com/Lusat's+Glintstone+Staff)
-  - Location: Sellia, Town of Sorcery: Found in a chest north of the Nox Swordstress & Nox Priest boss duo's chamber after defeating them.
+  - **Location:** Sellia, Town of Sorcery: Found in a chest north of the Nox Swordstress & Nox Priest boss duo's chamber after defeating them.
   - Enhances power of all sorceries, but consumes additional 50% FP.
   - No increase to sorcery damage outside of innate sorcery scaling
-- [Carian Glintstone Staff](https://eldenring.wiki.fextralife.com/Carian+Glintstone+Staff)
-  - Location: Located on a corpse in Carian Study Hall right before the second lift in Liurnia of the Lakes
+- :heavy_check_mark: [Carian Glintstone Staff](https://eldenring.wiki.fextralife.com/Carian+Glintstone+Staff)
+  - **Location:** Located on a corpse in Carian Study Hall right before the second lift in Liurnia of the Lakes
   - You receive the boost to Sword Sorceries even if you are wielding it in your off-hand while not meeting the requirements for it, making it great for dual-wielding staffs.
 
 ## Spells (Weapon Icon)
 
 - :heavy_check_mark: [Starlight](https://eldenring.wiki.fextralife.com/Starlight)
-  - Location: Starlight can be learned from Thops at the Church of Irith for runes currency elden ring wiki guide 18 2500 Runes
-  - Duration: 180 seconds
-- [Terra Magica](https://eldenring.wiki.fextralife.com/Terra+Magica)
-  - Location: Requires completion of the Academy Crystal Cave dungeon and taking the elevator behind the Crystalians bosses. This leads to a tower inside the academy, on the top of which a chest containing the spell can be found
+  - **Location:** Starlight can be learned from Thops at the Church of Irith for runes currency elden ring wiki guide 18 2500 Runes
+  - **Duration:** 180 seconds
+- :heavy_check_mark: [Terra Magica](https://eldenring.wiki.fextralife.com/Terra+Magica)
+  - **Location:** Requires completion of the Academy Crystal Cave dungeon and taking the elevator behind the Crystalians bosses. This leads to a tower inside the academy, on the top of which a chest containing the spell can be found
   - Creates a spherical zone centered on a sigil, giving you a magic buff, increasing magic damage from any source by 35%, lasting 30 seconds. Must be within the spell radius when damage is dealt to receive the buff.
 - [Loretta's Greatbow](https://eldenring.wiki.fextralife.com/Loretta's+Greatbow)
-  - Location: Caria Manor, Dropped by Royal Knight Loretta upon defeat.
+  - **Location:** Caria Manor, Dropped by Royal Knight Loretta upon defeat.
   - If fully charged, it does roughly 22% more damage.
-- [Carian Greatsword](https://eldenring.wiki.fextralife.com/Carian+Greatsword)
-  - Location: Can be purchased from Miriel, Pastor of Vows at the Church of Vows for runes currency elden ring wiki guide 18 10,000 Runes.
+- :heavy_check_mark: [Carian Greatsword](https://eldenring.wiki.fextralife.com/Carian+Greatsword)
+  - **Location:** Can be purchased from Miriel, Pastor of Vows at the Church of Vows for runes currency elden ring wiki guide 18 10,000 Runes.
   - Considered a Carian Sword Sorcery and a Cold Sorcery
 - [Adula's Moonblade](https://eldenring.wiki.fextralife.com/Adula's+Moonblade)
-  - Location: Dropped by the Glintstone Dragon Adula located at the Cathedral of Manus Celes
+  - **Location:** Dropped by the Glintstone Dragon Adula located at the Cathedral of Manus Celes
   - Considered a Carian Sword Sorcery and a Cold Sorcery
-- [Carian Slicer](https://eldenring.wiki.fextralife.com/Carian+Slicer)
-  - Location: After giving the Royal House Scroll to Miriel Pastor of Vows the spell can be purchased for runes currency elden ring wiki guide 18 1,500 Runes.
+- :heavy_check_mark: [Carian Slicer](https://eldenring.wiki.fextralife.com/Carian+Slicer)
+  - **Location:** After giving the Royal House Scroll to Miriel Pastor of Vows the spell can be purchased for runes currency elden ring wiki guide 18 1,500 Runes.
   - Has the highest magic damage per FP ratio out of all spells.
 - [Cannon of Haima](https://eldenring.wiki.fextralife.com/Cannon+of+Haima)
-  - Location: Can be found in the chest at the top of the Converted Fringe Tower in the northeast of the Liurnia of the Lakes region
+  - **Location:** Can be found in the chest at the top of the Converted Fringe Tower in the northeast of the Liurnia of the Lakes region
+    - **Note:** _Bring Thops the :heavy_check_mark: Academy Glintstone Key.  This gives the Erudition gesture, used to solve the tower puzzle._
   - When charged, deals (Sorcery Scaling x 3.12) magic damage.
 - [Gavel of Haima](https://eldenring.wiki.fextralife.com/Gavel+of+Haima)
-  - Location: Can be found in the chest at the top of the Converted Fringe Tower in the Liurnia of the Lakes region.
+  - **Location:** Can be found in the chest at the top of the Converted Fringe Tower in the Liurnia of the Lakes region.
+    - **Note:** _Bring Thops the :heavy_check_mark: Academy Glintstone Key.  This gives the Erudition gesture, used to solve the tower puzzle._
   - If dual wielding staves, you can bypass the single follow-up attack and chain this repeatedly by casting from one hand and then the other, alternating each time. 
 
 ## Weapons (Weapon Icon)
 
   - :heavy_check_mark: [Miséricorde](https://eldenring.wiki.fextralife.com/Misericorde)
-    - Location: Can be looted off a corpse that can be found in the large armory room, next to the fortress of the Grafted Scion.
+    - **Location:** Can be looted off a corpse that can be found in the large armory room, next to the fortress of the Grafted Scion.
     - The Miséricorde has the highest critical stat of all weapons in the game, at 140.
 
-## Ash of War (Weapon Icon)
+## :heavy_check_mark: Ash of War (Weapon Icon)
 
-  - [Determination](https://eldenring.wiki.fextralife.com/Ash+of+War:+Determination)
-    - Location: Dropped by a Teardrop Scarab on the path at the bridge north of Agheel Lake.
+  - :heavy_check_mark: [Determination](https://eldenring.wiki.fextralife.com/Ash+of+War:+Determination)
+    - **Location:** Dropped by a Teardrop Scarab on the path at the bridge north of Agheel Lake.
     - Buff the main hand, 10 seconds of 60% increase sourcery damage.  Use it for ranged.
 
 ## Armor (Weapon Icon)
 
   - [Queen's Crescent Crown](https://eldenring.wiki.fextralife.com/Queen's+Crescent+Crown)
-    - Location: Upon vanquishing Rennala, Queen of the Full Moon the Queen's Crescent Crown Helm becomes available for purchase at Enia in Roundtable Hold for runes currency elden ring wiki guide 18 7,000.
+    - **Location:** Upon vanquishing Rennala, Queen of the Full Moon the Queen's Crescent Crown Helm becomes available for purchase at Enia in Roundtable Hold for runes currency elden ring wiki guide 18 7,000.
     - Buff the main hand, 10 seconds of 60% increase sourcery damage.  Use it for ranged.
   - [Spellblade's Gloves](https://eldenring.wiki.fextralife.com/Spellblade's+Gloves)
-    - Location: Roundtable Hold - Drops from Rogier.
+    - **Location:** Roundtable Hold - Drops from Rogier.
     - Increases Intelligence by 3.
 
 ## Talismans (Chest Icon)
@@ -104,83 +108,83 @@ Arcane|base
 ### Primary
 
   - [Moon of Nokstella](https://eldenring.wiki.fextralife.com/Moon+of+Nokstella)
-    - Location: In a chest underneath a massive throne in Nokstella, Eternal City.  
+    - **Location:** In a chest underneath a massive throne in Nokstella, Eternal City.  
     - The chest is in the highest room of the city, guarded by two mimic tears and a Nox warrior.
   - [Radagon Icon](https://eldenring.wiki.fextralife.com/Radagon+Icon)
-    - Location: Raya Lucaria Academy, the talisman is inside a treasure chest on the second floor near the Debate Parlor Site of Grace. From the Site of Grace, head north into the courtyard.  Make two hard rights, hugging the building's wall, and then jump over the fence -- you should see a ladder in front of you. Climb up the ladder and head through the broken glass window. The treasure chest is in the north section
+    - **Location:** Raya Lucaria Academy, the talisman is inside a treasure chest on the second floor near the Debate Parlor Site of Grace. From the Site of Grace, head north into the courtyard.  Make two hard rights, hugging the building's wall, and then jump over the fence -- you should see a ladder in front of you. Climb up the ladder and head through the broken glass window. The treasure chest is in the north section
     - Gives 30 virtual Dexterity, exclusively towards spellcasting.
   - [Magic Scorpion Charm](https://eldenring.wiki.fextralife.com/Magic+Scorpion+Charm)
-    - Location: Obtained by giving Preceptor Seluvis the Amber Starlight after Seluvis tells you about his scheme.  Cannot be obtained after Seluvius' death (which occurs when the Fingerslayer Blade is given to Ranni the Witch)
+    - **Location:** Obtained by giving Preceptor Seluvis the Amber Starlight after Seluvis tells you about his scheme.  Cannot be obtained after Seluvius' death (which occurs when the Fingerslayer Blade is given to Ranni the Witch)
     - Magic Scorpion Charm increases Magic Damage by 12%, but increases Physical Damage taken by 10%.
   - [Cerulean Amber Medallion](https://eldenring.wiki.fextralife.com/Cerulean+Amber+Medallion)
-    - Base Location: Base Talisman: Lakeside Crystal Cave: After defeating the Bloodhound Knight
-    - +1 Location: Castle Sol: Found on a corpse hanging by a wooden ledge above the southern walls of the castle. This area is accessed by climbing a ladder behind the church in the southeast and following the walls west. Beware the very powerful dual sword knight guarding the area. He can teleport behind you and perform long combos.
-    - +2 Location: Lunar Estate Ruins: Found in a treasure chest in an underground room northwest of the ruins. Look for an Imp Statue pressed up against the wall. This requires one Stonesword Key. The stairs are also concealed by an illusory floor. Simply hit the floor next to the Imp Statue to reveal the stairs
+    - :heavy_check_mark: **Base Location:** Base Talisman: Lakeside Crystal Cave: After defeating the Bloodhound Knight
+    - **+1 Location:** Castle Sol: Found on a corpse hanging by a wooden ledge above the southern walls of the castle. This area is accessed by climbing a ladder behind the church in the southeast and following the walls west. Beware the very powerful dual sword knight guarding the area. He can teleport behind you and perform long combos.
+    - **+2 Location:** Lunar Estate Ruins: Found in a treasure chest in an underground room northwest of the ruins. Look for an Imp Statue pressed up against the wall. This requires one Stonesword Key. The stairs are also concealed by an illusory floor. Simply hit the floor next to the Imp Statue to reveal the stairs
     - Cerulean Amber Medallion raises maximum FP by 7, 9, or 11% based off the variant.
 
 ### Secondary
 
 - [Graven-School Talisman](https://eldenring.wiki.fextralife.com/Graven-School+Talisman)
-  - Location: At Raya Lucaria Academy, from the Debate Parlor site of grace, head west and turn right before going down the stairs. You should see an empty bookshelf in front of you. Hit it to dispel the illusory wall, then follow the path. Go up the ladder (after picking up Comet from the chest and the Stonesword Key from behind the altar), head east, jump over the railing, and drop down through a hole. Drop down once more to find yourself in a room with many Living Jars; the talisman is next to the crystals. The door to the right leads back to the room below the one you started in, containing multiple Raya Lucaria Sorcerers and a Giant Living Jar.
+  - **Location:** At Raya Lucaria Academy, from the Debate Parlor site of grace, head west and turn right before going down the stairs. You should see an empty bookshelf in front of you. Hit it to dispel the illusory wall, then follow the path. Go up the ladder (after picking up Comet from the chest and the Stonesword Key from behind the altar), head east, jump over the railing, and drop down through a hole. Drop down once more to find yourself in a room with many Living Jars; the talisman is next to the crystals. The door to the right leads back to the room below the one you started in, containing multiple Raya Lucaria Sorcerers and a Giant Living Jar.
   - Graven-School Talisman raises the potency of Sorceries by 4%.
 - [Graven-Mass Talisman](https://eldenring.wiki.fextralife.com/Graven-Mass+Talisman)
-  - Location: Found in a chest atop Albinauric Rise, in the east of the Consecrated Snowfield.  Bring either Fanged Imp Ashes, Bewitching Branch, or use some Crystal Darts to solve the Albinauric Rise puzzle, which requires imps to fight each other.
+  - **Location:** Found in a chest atop Albinauric Rise, in the east of the Consecrated Snowfield.  Bring either Fanged Imp Ashes, Bewitching Branch, or use some Crystal Darts to solve the Albinauric Rise puzzle, which requires imps to fight each other.
   - Graven-Mass Talisman raises the potency of Sorceries by 8%.
 - [Stargazer Heirloom](https://eldenring.wiki.fextralife.com/Stargazer+Heirloom)
-  - Location: Found on a body lying at the top of the Divine Tower of Liurnia
+  - **Location:** Found on a body lying at the top of the Divine Tower of Liurnia
   - Raises Intelligence by 5.
 - [Ritual Sword Talisman](https://eldenring.wiki.fextralife.com/Ritual+Sword+Talisman)
-  - Location: Located in Lux Ruins, in a chest after defeating the boss, Demi-Human Queen Gilika.
+  - **Location:** Located in Lux Ruins, in a chest after defeating the boss, Demi-Human Queen Gilika.
   - Ritual Sword Talisman raises attack power by 10% when HP is at maximum.
-- [Green Turtle Talisman](https://eldenring.wiki.fextralife.com/Green+Turtle+Talisman)
-  - Location: Summonwater Village. In an underground area on the eastern outskirts of the village. Entering the area requires a Stonesword Key
+- :heavy_check_mark: [Green Turtle Talisman](https://eldenring.wiki.fextralife.com/Green+Turtle+Talisman)
+  - **Location:** Summonwater Village. In an underground area on the eastern outskirts of the village. Entering the area requires a Stonesword Key
   - Raises Stamina recovery speed by 8 per second (17.7%)
 
 ### Tertiary
-- [Cerulean Seed Talisman](https://eldenring.wiki.fextralife.com/Cerulean+Seed+Talisman)
-  - Location: It can be found in the rafters of the Carian Study Hall, next to a body.
+- :heavy_check_mark: [Cerulean Seed Talisman](https://eldenring.wiki.fextralife.com/Cerulean+Seed+Talisman)
+  - **Location:** It can be found in the rafters of the Carian Study Hall, next to a body.
   - Cerulean Seed Talisman boosts FP restoration from Flask of Cerulean Tears by 20%.
 - [Dragoncrest Shield Talisman](https://eldenring.wiki.fextralife.com/Dragoncrest+Shield+Talisman)
-  - Location: Base variant, Bestial Sanctum: Found on the bottom level of the structure below the surrounding cliffs.
-  - Location: +1 variant, Sainted Hero's Grave: Can be found in a locked imp's room, behind the Stonesword Key fog wall. When you reach the area with the big axes stomping the ground, you need to get on the first one and jump on the ledge on the left wall.
-  - Location: +2 variant, Crumbling Farum Azula: Looted from a corpse on floating chunk of debris in the northern section, between Dragon Temple Lift and Dragon Temple Rooftop.
+  - **Base Location:** Bestial Sanctum. found on the bottom level of the structure below the surrounding cliffs.
+  - **+1 Location:** Sainted Hero's Grave, can be found in a locked imp's room, behind the Stonesword Key fog wall. When you reach the area with the big axes stomping the ground, you need to get on the first one and jump on the ledge on the left wall.
+  - **+2 Location:** Crumbling Farum Azula, Looted from a corpse on floating chunk of debris in the northern section, between Dragon Temple Lift and Dragon Temple Rooftop.
   - Reduces Physical Damage taken 10/13/17%
 - [Dragoncrest Greatshield Talisman](https://eldenring.wiki.fextralife.com/Dragoncrest+Greatshield+Talisman)
-  - Location: Elphael, Brace of the Haligtree: Found in a chest on an elevated platform inside the large building in the northeast, guarded by several Pests. 
+  - **Location:** Elphael, Brace of the Haligtree, found in a chest on an elevated platform inside the large building in the northeast, guarded by several Pests. 
   - Reduces Physical Damage taken by 20%
 - [Gold Scarab](https://eldenring.wiki.fextralife.com/Golden+Scarab)
-  - Dropped by the Cleanrot Knight (Sickle) & Cleanrot Knight (Spear) dual boss found in the Abandoned Cave. It can be accessed by going east from the Smoldering Wall Site of Grace, and walking across the canyon by using tree branches.
+  - **Location:** Dropped by the Cleanrot Knight (Sickle) & Cleanrot Knight (Spear) dual boss found in the Abandoned Cave. It can be accessed by going east from the Smoldering Wall Site of Grace, and walking across the canyon by using tree branches.
   - Gold Scarab increases Rune acquisition by 20%.
 - [Silver Scarab](https://eldenring.wiki.fextralife.com/Silver+Scarab)
-  - Location: Found in a chest in Hidden Path to the Haligtree. In the large central room, there is a broken section of railing. There, you can drop down to an invisible platform, and walk to a small room. The chest is past an Illusory Wall
+  - **Location:** Found in a chest in Hidden Path to the Haligtree. In the large central room, there is a broken section of railing. There, you can drop down to an invisible platform, and walk to a small room. The chest is past an Illusory Wall
   - Silver Scarab raises Item Discovery by 75.
 
 ## Critical Items
 
 ### Memory Stones (Skull Icon)
 
-- Where to find:
-  - Found in a chest at the top of Oridys's Rise in Weeping Peninsula. 
-    - Note: Oridys's Rise involves a challenge before the tower can be accessed. See the [Oridys's Rise](https://eldenring.wiki.fextralife.com/Oridys's+Rise) page for details.
-  - Found in a chest on the top floor of the Converted Tower in western Liurnia of the Lakes. 
-    - Note: Converted Tower involves a challenge before the tower can be accessed. See the [Converted Tower](https://eldenring.wiki.fextralife.com/Converted+Tower) page for details.
-  - Dropped by the Red Wolf of Radagon at Raya Lucaria Academy. 
-  - Found in a chest at the top floor of Testu's Rise in northern Liurnia of the Lakes.
-     - Note: Testu's Rise involves a challenge before the tower can be accessed. See the [Testu's Rise](https://eldenring.wiki.fextralife.com/Testu's+Rise) page for details.
+- **Where to find:**
+  - :heavy_check_mark: Found in a chest at the top of Oridys's Rise in Weeping Peninsula. 
+    - **Note:** _Oridys's Rise involves a challenge before the tower can be accessed. See the [Oridys's Rise](https://eldenring.wiki.fextralife.com/Oridys's+Rise) page for details._
+  - :heavy_check_mark: Found in a chest on the top floor of the Converted Tower in western Liurnia of the Lakes. 
+    - **Note:** _Converted Tower involves a challenge before the tower can be accessed. See the [Converted Tower](https://eldenring.wiki.fextralife.com/Converted+Tower) page for details._
+  - :heavy_check_mark: Dropped by the Red Wolf of Radagon at Raya Lucaria Academy. 
+  - :heavy_check_mark: Found in a chest at the top floor of Testu's Rise in northern Liurnia of the Lakes.
+     - **Note:** _Testu's Rise involves a challenge before the tower can be accessed. See the [Testu's Rise](https://eldenring.wiki.fextralife.com/Testu's+Rise) page for details._
   - Found in a chest on the top floor of Seluvis's Rise in the Three Sisters sub-region.
   - Dropped by Demi-Human Queen Maggie, an optional boss in the northeast of Hermit Village in Mt. Gelmir. 
   - Found in a chest at the top floor of Lenne's Rise in eastern Caelid. 
-    - Note: Entering Lenne's Rise requires jumping onto the open balcony from the Spiritspring south of the tower.
+    - **Note:** _Entering Lenne's Rise requires jumping onto the open balcony from the Spiritspring south of the tower._
 
-- Where to purchase:
+- **Where to purchase:**
   - :heavy_check_mark: Purchasable from Twin Maiden Husks at the Roundtable Hold for 3,000 Runes.
 
-### Scrolls (Banner Icon)
+### :heavy_check_mark: Scrolls (Banner Icon)
 
-- Give all scrolls to [Miriel, Paster of Vows](https://eldenring.wiki.fextralife.com/Miriel+Pastor+of+Vows), as he does not move from his position at the Church of Vows, and you may give him both Sorcery scrolls and Incantation Prayerbooks. 
-- [Royal House Scroll](https://eldenring.wiki.fextralife.com/Royal+House+Scroll)
+- :heavy_check_mark: _Give all scrolls to [Miriel, Paster of Vows](https://eldenring.wiki.fextralife.com/Miriel+Pastor+of+Vows), as he does not move from his position at the Church of Vows, and you may give him both Sorcery scrolls and Incantation Prayerbooks._
+- :heavy_check_mark: [Royal House Scroll](https://eldenring.wiki.fextralife.com/Royal+House+Scroll)
   - Head southeast from the Agheel Lake South site of grace, head to the top of a cliff and you'll see a statue of an object that looks like the half piece of a bowl or a circle. Face the other way, to see a Knight. Keep going to a structure to see a man standing watching over the big structure, alongside a dead body with the scroll.
 - :heavy_check_mark: [Academy Scroll](https://eldenring.wiki.fextralife.com/Academy+Scroll)
   - Found in the graveyard just by the starting Site of Grace of Liurnia of the Lakes, Lake-Facing Cliffs. Guarded by several Skeletons.
-- [Conspectus Scroll](https://eldenring.wiki.fextralife.com/Conspectus+Scroll)
+- :heavy_check_mark: [Conspectus Scroll](https://eldenring.wiki.fextralife.com/Conspectus+Scroll)
   - Can be found near the Great Hall of the Raya Lucaria Academy. From the doorway, go left and you'll find a room, there is a body that you can loot to find the scroll. 


### PR DESCRIPTION
Part 3 Postmortem
- added green checks to gathered items
- fixed formatting in the Attributes section so that the notes are bullet points
- added instructions for acquiring Cannon and Gavel of Haima
- added bolding across location and note entries
- added italics across note entries