### PR TITLE
Magic Woman - Post P5 Fermentation

### DIFF
--- a/Elden Ring/Magic Woman.md
+++ b/Elden Ring/Magic Woman.md
@@ -2,23 +2,28 @@
 
 ## Basis
 
-[Astrologer](https://www.youtube.com/watch?v=ISLC9b7YLsg&)
+[Astrologer (Early Game)](https://www.youtube.com/watch?v=ISLC9b7YLsg&)
 
-[Prisoner](https://www.youtube.com/watch?v=k3TFfIzbN8I)
+[Prisoner (Early Game)](https://www.youtube.com/watch?v=k3TFfIzbN8I)
 
-[Melee Mage](https://www.youtube.com/watch?v=NXQXAGWjyh4)
+[Melee Mage (Early Game)](https://www.youtube.com/watch?v=NXQXAGWjyh4)
 
 [Spellblade (Early Game)](https://www.youtube.com/watch?v=OCDBjAPCepw)
 
 [Spellblade (Late Game)](https://www.youtube.com/watch?v=ng6NTaP4fPs)
 
-[ALL Sorcery Spells in Elden Ring](https://www.youtube.com/watch?v=gqSzUthyrsU)
+[Carian Spellknight (Late Game)](https://www.youtube.com/watch?v=OCDBjAPCepw)
+
+[ALL Sorcery Spells in Elden Ring (Showcase)](https://www.youtube.com/watch?v=gqSzUthyrsU)
 
 
 - This build will be a mixture of melee and long range magical spells, mostly the Carian Glintstone schools and the Carian Weapon Spells.  
-- Dagger is for buffing range spells with Determination and for cheeky counters/backstabs.
+- Dagger is for using the Carian Grandeur Ash of War and for cheeky counters/backstabs.
 - Ranged spells are big hitters by and large.  
-- Stay out of melee expect when pushed, then switch to Slicer/Greatsword or a cheeky back stab/counter if able.
+- Always attempt to use Terra Magica before using ranged spells.
+- Stay out of melee expect when pushed, then switch to Carian Slicer/Greatsword/Grandeur or a cheeky back stab/counter if able.
+- Use either Carian Regal Scepter or Lusat's Glintstone Staff for ranged combat, as needed.
+- Switch to Miséricorde when preforming melee combat.
 
 ## Attributes
 
@@ -40,7 +45,7 @@ Arcane|base
 
 ## Weapons / Gear
 
-### Staff (Weapon Icon)
+### :heavy_check_mark: Staff (Weapon Icon)
 
 - :heavy_check_mark: [Carian Regal Scepter](https://eldenring.wiki.fextralife.com/Carian+Regal+Scepter)
   - **Location:** Obtained when unlocking the Remembrance of The Full Moon Queen's power by handing it over to Enia at Roundtable Hold.
@@ -53,45 +58,56 @@ Arcane|base
   - **Location:** Located on a corpse in Carian Study Hall right before the second lift in Liurnia of the Lakes
   - You receive the boost to Sword Sorceries even if you are wielding it in your off-hand while not meeting the requirements for it, making it great for dual-wielding staffs.
 
-## Spells (Weapon Icon)
+## :heavy_check_mark: Spells (Weapon Icon)
 
-
-- :heavy_check_mark: [Glintstone Pebble](https://eldenring.wiki.fextralife.com/Glintstone+Pebble)
-  - **Location:** Provided as part of the Astrologer class.
-  - Early to mid game mana-efficent spell.  To be replaced by Glintstone Comentshard.
-- :heavy_check_mark: [Glintstone Cometshard](https://eldenring.wiki.fextralife.com/Glintstone+Cometshard)
-  - **Location:** The spell can be purchased for 12,000 Runes after you deliver the Conspectus Scroll to Miriel Pastor of Vows
-- :heavy_check_mark: [Carian Piercer](https://eldenring.wiki.fextralife.com/Carian+Piercer)
-  - **Location:** Caria Manor, dropped by a Teardrop Scarab in an area behind the gardens, to the east.
-  - Considered a Carian Sword Sorcery.
-- :heavy_check_mark: [Starlight](https://eldenring.wiki.fextralife.com/Starlight)
-  - **Location:** Starlight can be learned from Thops at the Church of Irith for runes currency elden ring wiki guide 18 2500 Runes
-  - **Duration:** 180 seconds
-- :heavy_check_mark: [Terra Magica](https://eldenring.wiki.fextralife.com/Terra+Magica)
-  - **Location:** Requires completion of the Academy Crystal Cave dungeon and taking the elevator behind the Crystalians bosses. This leads to a tower inside the academy, on the top of which a chest containing the spell can be found
-  - Creates a spherical zone centered on a sigil, giving you a magic buff, increasing magic damage from any source by 35%, lasting 30 seconds. Must be within the spell radius when damage is dealt to receive the buff.
-- :heavy_check_mark: [Loretta's Greatbow](https://eldenring.wiki.fextralife.com/Loretta's+Greatbow)
-  - **Location:** Caria Manor, Dropped by Royal Knight Loretta upon defeat.
-  - If fully charged, it does roughly 22% more damage.
-- :heavy_check_mark: [Carian Greatsword](https://eldenring.wiki.fextralife.com/Carian+Greatsword)
-  - **Location:** Can be purchased from Miriel, Pastor of Vows at the Church of Vows for runes currency elden ring wiki guide 18 10,000 Runes.
-  - Considered a Carian Sword Sorcery.
-- [Adula's Moonblade](https://eldenring.wiki.fextralife.com/Adula's+Moonblade)
-  - **Location:** Dropped by the Glintstone Dragon Adula located at the Cathedral of Manus Celes
-  - Considered a Carian Sword Sorcery and a Cold Sorcery
 - :heavy_check_mark: [Carian Slicer](https://eldenring.wiki.fextralife.com/Carian+Slicer)
   - **Location:** After giving the Royal House Scroll to Miriel Pastor of Vows the spell can be purchased for runes currency elden ring wiki guide 18 1,500 Runes.
+  - **FP Cost:** 4
   - Has the highest magic damage per FP ratio out of all spells.
-- :heavy_check_mark: [Cannon of Haima](https://eldenring.wiki.fextralife.com/Cannon+of+Haima)
-  - **Location:** Can be found in the chest at the top of the Converted Fringe Tower in the northeast of the Liurnia of the Lakes region
-    - **Note:** _Bring Thops the :heavy_check_mark: Academy Glintstone Key.  This gives the Erudition gesture, used to solve the tower puzzle._
-  - When charged, deals (Sorcery Scaling x 3.12) magic damage.
+- :heavy_check_mark: [Carian Greatsword](https://eldenring.wiki.fextralife.com/Carian+Greatsword)
+  - **Location:** Can be purchased from Miriel, Pastor of Vows at the Church of Vows for runes currency elden ring wiki guide 18 10,000 Runes.
+  - **FP Cost:** 12	
+  - Considered a Carian Sword Sorcery.
+- :heavy_check_mark: [Carian Piercer](https://eldenring.wiki.fextralife.com/Carian+Piercer)
+  - **Location:** Caria Manor, dropped by a Teardrop Scarab in an area behind the gardens, to the east.
+  - **FP Cost:** 17
+  - Considered a Carian Sword Sorcery.
 - :heavy_check_mark: [Gavel of Haima](https://eldenring.wiki.fextralife.com/Gavel+of+Haima)
   - **Location:** Can be found in the chest at the top of the Converted Fringe Tower in the Liurnia of the Lakes region.
     - **Note:** _Bring Thops the :heavy_check_mark: Academy Glintstone Key.  This gives the Erudition gesture, used to solve the tower puzzle._
+  - **FP Cost:* 22
   - If dual wielding staves, you can bypass the single follow-up attack and chain this repeatedly by casting from one hand and then the other, alternating each time. 
+- :heavy_check_mark: [Glintstone Pebble](https://eldenring.wiki.fextralife.com/Glintstone+Pebble)
+  - **Location:** Provided as part of the Astrologer class.
+  - **FP Cost:** 7
+  - Early to mid game mana-efficent spell.  To be replaced by Glintstone Comentshard.
+  - To be replaced by Glintstone Comentshard.
+- :heavy_check_mark: [Glintstone Cometshard](https://eldenring.wiki.fextralife.com/Glintstone+Cometshard)
+  - **Location:** The spell can be purchased for 12,000 Runes after you deliver the Conspectus Scroll to Miriel Pastor of Vows
+  - **FP Cost:** 17  
+  - Can be charged for up to approximately 20-25% increased damage.
+  - The projectile of this sorcery includes a comet tail (the outer dust of the projectile), dealing damage itself and thus adding a little bit of AoE-damage to the spell. Fired in a group of enemies, it will often hurt also the nearest bystanders of the target.
+  - Compared to Glintstone Pebble, Glintstone Cometshard costs about 135% more FP, travels 15-20% farther and deals about 70-80% more damage.
+  - To replace Glintstone Pebble.
+- :heavy_check_mark: [Loretta's Greatbow](https://eldenring.wiki.fextralife.com/Loretta's+Greatbow)
+  - **Location:** Caria Manor, Dropped by Royal Knight Loretta upon defeat.
+  - **FP Cost:** 24	
+  - If fully charged, it does roughly 22% more damage.
+- :heavy_check_mark: [Cannon of Haima](https://eldenring.wiki.fextralife.com/Cannon+of+Haima)
+  - **Location:** Can be found in the chest at the top of the Converted Fringe Tower in the northeast of the Liurnia of the Lakes region.
+    - **Note:** _Bring Thops the :heavy_check_mark: Academy Glintstone Key.  This gives the Erudition gesture, used to solve the tower puzzle._
+  - **FP Cost:** 38
+  - When charged, deals (Sorcery Scaling x 3.12) magic damage.
+- :heavy_check_mark: [Terra Magica](https://eldenring.wiki.fextralife.com/Terra+Magica)
+  - **Location:** Requires completion of the Academy Crystal Cave dungeon and taking the elevator behind the Crystalians bosses. This leads to a tower inside the academy, on the top of which a chest containing the spell can be found.
+  - **FP Cost:** 20
+  - Creates a spherical zone centered on a sigil, giving you a magic buff, increasing magic damage from any source by 35%, lasting 30 seconds. Must be within the spell radius when damage is dealt to receive the buff.
+- :heavy_check_mark: [Starlight](https://eldenring.wiki.fextralife.com/Starlight)
+  - **Location:** Starlight can be learned from Thops at the Church of Irith for runes currency elden ring wiki guide 18 2500 Runes
+  - **FP Cost:** 9
+  - **Duration:** 180 seconds
 
-## Weapons (Weapon Icon)
+## :heavy_check_mark: Weapons (Weapon Icon)
 
   - :heavy_check_mark: [Miséricorde](https://eldenring.wiki.fextralife.com/Misericorde)
     - **Location:** Can be looted off a corpse that can be found in the large armory room, next to the fortress of the Grafted Scion.
@@ -99,9 +115,13 @@ Arcane|base
 
 ## :heavy_check_mark: Ash of War (Weapon Icon) 
 
-  - :heavy_check_mark: [Determination](https://eldenring.wiki.fextralife.com/Ash+of+War:+Determination)
-    - **Location:** Dropped by a Teardrop Scarab on the path at the bridge north of Agheel Lake.
+  - :heavy_check_mark: [Carian Grandeur](https://eldenring.wiki.fextralife.com/Carian+Grandeur)
+    - **Location:** Found in Caria Manor, high above a large stone structure. This is accessible by climbing down the cliffside graveyard from the manor's upper level.
+    - **FP Cost:** 26
     - Buff the main hand, 10 seconds of 60% increase sourcery damage.  Use it for ranged.
+    - This Skill is Chargeable.
+    - Deals 25 Poise Damage on hit, 30 when fully charged.
+    - Is outperformed by Carian Greatsword in terms of damage if Carian Grandeur is only charged once, but charges more quickly, making it easier to use.
 
 ## Armor (Weapon Icon)
 
@@ -117,7 +137,7 @@ Arcane|base
 ### Primary
 
  - :heavy_check_mark: [Radagon Icon](https://eldenring.wiki.fextralife.com/Radagon+Icon)
-   - **Location:** Raya Lucaria Academy, the talisman is inside a treasure chest on the second floor near the Debate Parlor Site of Grace. From the Site of Grace, head north into the courtyard.  Make two hard rights, hugging the building's wall, and then jump over the fence -- you should see a ladder in front of you. Climb up the ladder and head through the broken glass window. The treasure chest is in the north section
+   - **Location:** Raya Lucaria Academy, the talisman is inside a treasure chest on the second floor near the Debate Parlor Site of Grace. From the Site of Grace, head north into the courtyard.  Make two hard rights, hugging the building's wall, and then jump over the fence -- you should see a ladder in front of you. Climb up the ladder and head through the broken glass window. The treasure chest is in the north section.
    - Gives 30 virtual Dexterity, exclusively towards spellcasting.
  - [Magic Scorpion Charm](https://eldenring.wiki.fextralife.com/Magic+Scorpion+Charm)
    - **Location:** Obtained by giving Preceptor Seluvis the Amber Starlight after Seluvis tells you about his scheme.  Cannot be obtained after Seluvius' death (which occurs when the Fingerslayer Blade is given to Ranni the Witch)
@@ -125,28 +145,28 @@ Arcane|base
 - :heavy_check_mark: [Graven-School Talisman](https://eldenring.wiki.fextralife.com/Graven-School+Talisman)
   - **Location:** At Raya Lucaria Academy, from the Debate Parlor site of grace, head west and turn right before going down the stairs. You should see an empty bookshelf in front of you. Hit it to dispel the illusory wall, then follow the path. Go up the ladder (after picking up Comet from the chest and the Stonesword Key from behind the altar), head east, jump over the railing, and drop down through a hole. Drop down once more to find yourself in a room with many Living Jars; the talisman is next to the crystals. The door to the right leads back to the room below the one you started in, containing multiple Raya Lucaria Sorcerers and a Giant Living Jar.
   - Graven-School Talisman raises the potency of Sorceries by 4%.
-  - To be replaced by Graven-Mass Talisman
+  - To be replaced by Graven-Mass Talisman.
 - [Graven-Mass Talisman](https://eldenring.wiki.fextralife.com/Graven-Mass+Talisman)
   - **Location:** Found in a chest atop Albinauric Rise, in the east of the Consecrated Snowfield.  Bring either Fanged Imp Ashes, Bewitching Branch, or use some Crystal Darts to solve the Albinauric Rise puzzle, which requires imps to fight each other.
   - Graven-Mass Talisman raises the potency of Sorceries by 8%.
-  - To replace Graven-School Talisman
+  - To replace Graven-School Talisman.
 
 ### Secondary
 
  - [Cerulean Amber Medallion](https://eldenring.wiki.fextralife.com/Cerulean+Amber+Medallion)
    - :heavy_check_mark: **Base Location:** Base Talisman: Lakeside Crystal Cave: After defeating the Bloodhound Knight
    - **+1 Location:** Castle Sol: Found on a corpse hanging by a wooden ledge above the southern walls of the castle. This area is accessed by climbing a ladder behind the church in the southeast and following the walls west. Beware the very powerful dual sword knight guarding the area. He can teleport behind you and perform long combos.
-   - **+2 Location:** Lunar Estate Ruins: Found in a treasure chest in an underground room northwest of the ruins. Look for an Imp Statue pressed up against the wall. This requires one Stonesword Key. The stairs are also concealed by an illusory floor. Simply hit the floor next to the Imp Statue to reveal the stairs
+   - **+2 Location:** Lunar Estate Ruins: Found in a treasure chest in an underground room northwest of the ruins. Look for an Imp Statue pressed up against the wall. This requires one Stonesword Key. The stairs are also concealed by an illusory floor. Simply hit the floor next to the Imp Statue to reveal the stairs.
    - Cerulean Amber Medallion raises maximum FP by 7, 9, or 11% based off the variant.
 - [Stargazer Heirloom](https://eldenring.wiki.fextralife.com/Stargazer+Heirloom)
-  - **Location:** Found on a body lying at the top of the Divine Tower of Liurnia
+  - **Location:** Found on a body lying at the top of the Divine Tower of Liurnia.
   - Raises Intelligence by 5.
 - [Ritual Sword Talisman](https://eldenring.wiki.fextralife.com/Ritual+Sword+Talisman)
   - **Location:** Located in Lux Ruins, in a chest after defeating the boss, Demi-Human Queen Gilika.
   - Ritual Sword Talisman raises attack power by 10% when HP is at maximum.
 - :heavy_check_mark: [Green Turtle Talisman](https://eldenring.wiki.fextralife.com/Green+Turtle+Talisman)
-  - **Location:** Summonwater Village. In an underground area on the eastern outskirts of the village. Entering the area requires a Stonesword Key
-  - Raises Stamina recovery speed by 8 per second (17.7%)
+  - **Location:** Summonwater Village. In an underground area on the eastern outskirts of the village. Entering the area requires a Stonesword Key.
+  - Raises Stamina recovery speed by 8 per second (17.7%).
 
 ### Tertiary
 - :heavy_check_mark: [Cerulean Seed Talisman](https://eldenring.wiki.fextralife.com/Cerulean+Seed+Talisman)
@@ -156,10 +176,10 @@ Arcane|base
   - **Base Location:** Bestial Sanctum. found on the bottom level of the structure below the surrounding cliffs.
   - **+1 Location:** Sainted Hero's Grave, can be found in a locked imp's room, behind the Stonesword Key fog wall. When you reach the area with the big axes stomping the ground, you need to get on the first one and jump on the ledge on the left wall.
   - **+2 Location:** Crumbling Farum Azula, Looted from a corpse on floating chunk of debris in the northern section, between Dragon Temple Lift and Dragon Temple Rooftop.
-  - Reduces Physical Damage taken 10/13/17%
+  - Reduces Physical Damage taken 10/13/17%.
 - [Dragoncrest Greatshield Talisman](https://eldenring.wiki.fextralife.com/Dragoncrest+Greatshield+Talisman)
   - **Location:** Elphael, Brace of the Haligtree, found in a chest on an elevated platform inside the large building in the northeast, guarded by several Pests. 
-  - Reduces Physical Damage taken by 20%
+  - Reduces Physical Damage taken by 20%.
 - [Gold Scarab](https://eldenring.wiki.fextralife.com/Golden+Scarab)
   - **Location:** Dropped by the Cleanrot Knight (Sickle) & Cleanrot Knight (Spear) dual boss found in the Abandoned Cave. It can be accessed by going east from the Smoldering Wall Site of Grace, and walking across the canyon by using tree branches.
   - Gold Scarab increases Rune acquisition by 20%.
@@ -191,8 +211,8 @@ Arcane|base
 
 - :heavy_check_mark: _Give all scrolls to [Miriel, Paster of Vows](https://eldenring.wiki.fextralife.com/Miriel+Pastor+of+Vows), as he does not move from his position at the Church of Vows, and you may give him both Sorcery scrolls and Incantation Prayerbooks._
 - :heavy_check_mark: [Royal House Scroll](https://eldenring.wiki.fextralife.com/Royal+House+Scroll)
-  - Head southeast from the Agheel Lake South site of grace, head to the top of a cliff and you'll see a statue of an object that looks like the half piece of a bowl or a circle. Face the other way, to see a Knight. Keep going to a structure to see a man standing watching over the big structure, alongside a dead body with the scroll.
+  - **Location:** Head southeast from the Agheel Lake South site of grace, head to the top of a cliff and you'll see a statue of an object that looks like the half piece of a bowl or a circle. Face the other way, to see a Knight. Keep going to a structure to see a man standing watching over the big structure, alongside a dead body with the scroll.
 - :heavy_check_mark: [Academy Scroll](https://eldenring.wiki.fextralife.com/Academy+Scroll)
-  - Found in the graveyard just by the starting Site of Grace of Liurnia of the Lakes, Lake-Facing Cliffs. Guarded by several Skeletons.
+  - **Location:** Found in the graveyard just by the starting Site of Grace of Liurnia of the Lakes, Lake-Facing Cliffs. Guarded by several Skeletons.
 - :heavy_check_mark: [Conspectus Scroll](https://eldenring.wiki.fextralife.com/Conspectus+Scroll)
-  - Can be found near the Great Hall of the Raya Lucaria Academy. From the doorway, go left and you'll find a room, there is a body that you can loot to find the scroll. 
+  - **Location:** Great Hall of the Raya Lucaria Academy. From the doorway, go left and you'll find a room, there is a body that you can loot to find the scroll. 


### PR DESCRIPTION
Updated Ash of War
 - Removed the Determination Ash of War.  It was useless and cumbersome to use effectively.
 - Added the Carian Grandeur Ash of War.  Fits character RP better and "does a lot of damage"
 - Added FP Cost

Spells Update
 - Added FP Costs across all spells.
 - Removed Adula's Moonblade, high FP cost per performance in addition to it being a cold based sorcery.  Not in line with character RP.
 - Organized spells by spell order in game.

Updated Basics Section
- Updated all build guide videos to denote early or late game.
- Updated Dagger Ash of War information
- Added Carian Spellknight build guide video
- Added playstyle information.

Fixed grammatical and syntax errors for sentences across entire guide. Fixed Location entry style on several items across guide Added Check marks to completed section headers.