### PR TITLE
Add Rock James build for Elden Ring

### DIFF
--- a/Elden Ring/Rock James Build.md
+++ b/Elden Ring/Rock James Build.md
@@ -1,0 +1,142 @@
+# Rock James Build
+
+## Basis
+
+- [Barbarian (Beginner Guide)](https://www.youtube.com/watch?v=cPA5joRvYyk)
+- [Colossal Knight (50)](https://www.youtube.com/watch?v=KU-kiZvnOxU)
+- [Colossus Guardian (100)](https://www.youtube.com/watch?v=voRoe8vnNxI)
+- [Colossal Crusher (150)](https://www.youtube.com/watch?v=W8H6h8dhp6E)
+
+## Starting Classes
+
+- Hero
+- Vagabond
+
+## Attributes
+
+| Name         | Value |
+| ------------ | ----- |
+| Vigor        | 53    |
+| Mind         | 18    |
+| Endurance    | 36    |
+| Strength     | 80    |
+| Dexterity    | 12    |
+| Intelligence | 9     |
+| Faith        | 14    |
+| Arcane       | 9     |
+
+_Strength has value all the way up to 99 given the excellent scaling mechanics of this build._
+
+## Weapons
+
+### Melee
+
+- [Dagger](https://eldenring.wiki.fextralife.com/Dagger) scales primarily with Strength and Dexterity and is a good Weapon for short-ranged melee combat, and for when you need an extra lightweight utility weapon on hand.
+  - Can be purchased from Twin Maiden Husks at the Roundtable Hold for 400 Runes.
+  - Can be dropped by Highwaymen and different types of Foot Soldiers.
+    - Multiple soldiers can be encountered early in the game at the camp east of Warmaster's Shack.
+- [Giant-Crusher](https://eldenring.wiki.fextralife.com/Giant-Crusher) scales primarily with Strength and is a good Weapon for dealing great physical damage, but this heavy weapon also requires great Strength to wield.
+  - Can be found in a chest in the back of a Carriage directly to the south of Outer Wall Phantom Tree site of grace.
+- [Great Stars](https://eldenring.wiki.fextralife.com/Great+Stars) scales primarily with Strength and Dexterity, and is a good Weapon for high-strength characters who can hold this weapon's weight.
+  - On a guarded Carriage being towed by two Trolls in Altus Plateau, travelling on the road southwest of the Road of Iniquity Side Path Site of Grace.
+  - Dropped by Magnus the Beast Claw upon defeat.
+- [Greatsword](https://eldenring.wiki.fextralife.com/Greatsword) scales primarily with Strength and is a good Weapon for cleaving many foes at once with its wide swings.
+  - Found in Caelid, Dragonbarrow. North-west to the Caelem Ruins Site of Grace, inside the chest in the back of the Carriage guarded by Giant Dogs.
+- [Highland Axe](https://eldenring.wiki.fextralife.com/Highland+Axe) scales primarily with Strength and Dexterity and is a fine Weapon for combat when an attack boost is needed.
+  - Location: Stormveil Castle.
+  - Looted off a corpse inside the fortress of the Grafted Scion. The body can be found resting under the large painting that's at the center of the room.
+- [Prelate's Blood Inferno Crozier](https://eldenring.wiki.fextralife.com/Prelate's+Inferno+Crozier) scales primarily with Strength and Dexterity and is a good Weapon for strong melee attacks that will fling enemies into the air.
+  - Drops from a Fire Prelate wielding it inside Fort Laiedd near Seethewater Terminus Site of Grace. This drop is guaranteed once per playthrough.
+- [Whetstone Knife](https://eldenring.wiki.fextralife.com/Whetstone+Knife) can add new battle arts and affinities to weapons.
+  - Found in the southeastern area of Gatefront Ruins. There is a set of stairs leading to a small room underground where a treasure chest can be found. Inside the chest is the Whetstone Knife and Ash of War: Storm Stomp.
+- [Zweihander](https://eldenring.wiki.fextralife.com/Zweihander) scales primarily with Strength and Dexterity, and is a versatile Weapon for heavy-weight combat.
+  - Can be purchased from the Isolated Merchant for 3,500 Runes. He can be found in his shack at the very west of the Weeping Peninsula.
+
+### Ranged
+
+- [Clawmark Seal](https://eldenring.wiki.fextralife.com/Clawmark+Seal) is a Weapon for characters that wish to use beast Incantations without investing in faith.
+  - Given by Gurranq Beast Clergyman after feeding him a Deathroot.
+
+## Ashes of War
+
+- [Troll's Roar](https://eldenring.wiki.fextralife.com/Troll's+Roar) allows the user to distance himself from nearby enemies by generating a shockwave that blows them back.
+  - Default skill on the Troll's Hammer, Troll's Golden Sword, and Troll Knight's Sword.
+  - Can be found on the top of the big rock just south east the Church of Repose (in Mountaintops of the Giants).
+- [War Cry](https://eldenring.wiki.fextralife.com/Ash+of+War:+War+Cry) provides Heavy affinity and the War Cry Skill. Give a war cry to rally the spirit and increase attack power. While active, strong attacks change to charging attacks.
+  - Sold by Knight Bernahl at the Warmaster's Shack for 800 runes.
+  - Can be purchased from Twin Maiden Husks at the Roundtable Hold after giving them Bernahl's Bell Bearing.
+
+## Armor
+
+- [Bull-Goat Set](https://eldenring.wiki.fextralife.com/Bull-Goat+Set) Great Horned Tragoth's Armor Set. Covers its wearer with a pair of giant horns, providing staunch poise.
+  - Once Patches has moved to Volcano Manor during his questline, he will give you a letter to kill Great Horned Tragoth. Note that you need to join the Volcano Manor covenant and do a kill mission first for Patches to show up and give you this kill mission. You get the armor set immediately after killing Tragoth.
+- [Fire Prelate Set](https://eldenring.wiki.fextralife.com/Fire+Prelate+Set) is a rather heavy armor set, but offers good defences, particularly against Fire.
+  - The full set is dropped by Fire Prelate enemies.
+  - The full set with the non-altered armor is dropped by the Fire Prelate in front of the Guardian's Garrison in Mountaintops of the Giants.
+  - The Fire Prelate Armor (Altered) is dropped by the Fire Prelate in Fort Laiedd, Mt. Gelmir.
+- [Omensmirk Mask](https://eldenring.wiki.fextralife.com/Omensmirk+Mask) is a Lightweight headpiece that increases Strength.
+  - Dropped by a lesser Omenkiller outside of the Lower Capital Church Site of Grace in Leyndell, Royal Capital.
+
+_Heavy armor with poise above all else. Two-handing a weapon with slow swings comes with the expectation you'll trade blows, and having high poise reduces the likelihood you'll be staggered while attacking._
+
+## Talismans
+
+- [Assassin's Cerulean Dagger](https://eldenring.wiki.fextralife.com/Assassin's+Cerulean+Dagger) causes critical attacks to restore 15 FP.
+  - Dropped by the Black Knife Assassin boss found in Black Knife Catacombs in the northeast of the Liurnia of the Lakes region.
+- [Assassin's Crimson Dagger](https://eldenring.wiki.fextralife.com/Assassin's+Crimson+Dagger) causes critical attacks to restore 10% +85 HP.
+  - Can be found inside the Deathtouched Catacombs, dropped by the Black Knife Assassin.
+- [Axe Talisman](https://eldenring.wiki.fextralife.com/Axe+Talisman) increases charged attack damage by 10%.
+  - Found in a cellar underneath the Mistwood Ruins.
+- [Bull-Goat's Talisman](https://eldenring.wiki.fextralife.com/Bull-Goat's+Talisman) reduces Poise Damage by 25%.
+  - In the back of Dragonbarrow Cave. From the entrance, take a left into the Giant Bear's patrol route. Search that side of the cave and it will be at the end of it on a corpse.
+- [Claw Talisman](https://eldenring.wiki.fextralife.com/Claw+Talisman) increases jump attack damage by 15%.
+  - Located at Stormveil Castle, on a corpse situated on a watchtower.
+- [Dragoncrest Greatshield Talisman](https://eldenring.wiki.fextralife.com/Dragoncrest+Greatshield+Talisman) enormously reduces Physical Damage taken, by 20%.
+  - Elphael, Brace of the Haligtree: Found in a chest on an elevated platform inside the large building in the northeast, guarded by several Pests.
+- [Erdtree's Favor](https://eldenring.wiki.fextralife.com/Erdtree's+Favor) raises user's maximum HP, Stamina, and Equip Load.
+  - Base talisman: Fringefolk Hero's Grave: To get there, use two Stonesword Keys on the double Imp Keystone next to the Stranded Graveyard Site of Grace. This will lead to a mini-dungeon with traps. Head down until you see the path narrow on both sides and drop drown at the edge to get access to the secret area. Proceed past the imps and a fire trap to find the item resting at an altar.
+  - +1 Variant: Subterranean Shunning-Grounds: Can be found in a chest, in the boss room after the boss fight with Mohg, the Omen.
+  - +2 Variant: Leyndell, Ashen Capital: Found on top of a branch jutting out of the ground in a large courtyard, guarded by three Lesser Ulcerated Tree Spirits.
+- [Great-Jar's Arsenal](https://eldenring.wiki.fextralife.com/Great-Jar's+Arsenal) raises maximum Equip Load by 19%.
+  - Reward for completing the The Great-Jar's challenge of defeating three NPC duelists in Dragonbarrow (northern Caelid).
+  - You must kill all three NPC duelists in one life; dying will make it so you have to start from the first duelist again. You can access this area by coming up from Siofra Deep River Well in the underground.
+    - This area can also be accessed by climbing the roots above the large crystal at the bottom of the valley. However, this is most likely unintentional.
+  - Obtaining this talisman while playing online results in player's build being uploaded to the Elden Ring server to be used as randomized Knight of the Great Jar for other players.
+  - When you talk to the Great-Jar, he will only respond with "..."
+  - After talking to him, three red summon signs appear to summon three Knights of the Great-Jar.
+    - In two of the four corners of the "arena", there are narrow rock outcroppings. Crouching or blocking in these spots will often cause the NPCs to fall off of the cliff as they attack. This is especially useful when sequence-breaking into this area with a low-level character.
+    - Consider killing the closer of the two archer golems, as he will shoot arrows at you and disrupt your fights.
+- [Green Turtle Talisman](https://eldenring.wiki.fextralife.com/Green+Turtle+Talisman) raises Stamina recovery speed by 8 per second (17.7%).
+  - Summonwater Village. In an underground area on the eastern outskirts of the village. Entering the area requires a Stonesword Key.
+- [Lord of Blood's Exultation](https://eldenring.wiki.fextralife.com/Lord+of+Blood's+Exultation) raises attack power by 20% for 20 seconds when Blood Loss occurs in the vicinity.
+  - Drops from Esgar, Priest of Blood in Leyndell Catacombs.
+- [Radagon's Soreseal](https://eldenring.wiki.fextralife.com/Radagon's+Soreseal) raises Vigor, Endurance, Strength, and Dexterity by 5 each, but increases damage taken by 15%.
+  - Fort Faroth: Found on a corpse by dropping down the opening from the roof and exploring around the wooden walkways.
+- [Roar Medallion](https://eldenring.wiki.fextralife.com/Roar+Medallion) increases the damage of roars and breath attacks by 15%.
+  - Dropped by the Stonedigger Troll, located in the Limgrave Tunnels. He is found at the end of the dungeon.
+- [Shard of Alexander](https://eldenring.wiki.fextralife.com/Shard+of+Alexander) greatly boosts the attack power of Skills by 15%.
+  - Drops from Iron Fist Alexander after completing his questline.
+- [Viridian Amber Medallion](https://eldenring.wiki.fextralife.com/Viridian+Amber+Medallion) raises maximum Stamina by 11/13/15%.
+  - Base talisman: Tombsward Cave, a small dungeon in the Weeping Peninsula: Located southeast of the Fourth Church of Marika. The medallion is obtained after defeating the boss, Miranda the Blighted Bloom.
+  - +1 Variant: Altus Plauteau, south of the Outer Wall Battleground Site of Grace: You will hear Margit whisper, "I see you, Tarnished..." to you before appearing on the road. Defeat him again and it will drop.
+  - +2 Variant: Miquella's Haligtree: The closest site of grace is the Haligtree Town Plaza. Go south towards the roof with a dead body on it. For reference, the dead body is two stories above the talisman.
+- [Winged Sword Insignia](https://eldenring.wiki.fextralife.com/Winged+Sword+Insignia) increases attack power with each successive attack.
+  - Stillwater Cave: Dropped by the Cleanrot Knight boss upon defeat.
+
+## Spells
+
+- [Bestial Vitality](https://eldenring.wiki.fextralife.com/Bestial+Vitality) is a healing Incantation that restores caster's HP over time.
+  - Bestial Sanctum: Reward from Gurranq, Beast Clergyman after giving him the third Deathroot.
+- [Flame, Grant Me Strength](https://eldenring.wiki.fextralife.com/Flame+Grant+me+Strength) raises physical and fire-affinity attack power.
+  - Found behind Fort Gael, on a body between two Flame Chariots.
+
+## Wondrous Flask of Physick
+
+- [Greenburst Crystal Tear](https://eldenring.wiki.fextralife.com/Greenburst+Crystal+Tear) increases Stamina recovery speed by 15 per second for 3 minutes.
+  - Dropped by the Erdtree Avatar found at the Minor Erdtree in Caelid, east of Smoldering Church.
+- [Leaded Hardtear](https://eldenring.wiki.fextralife.com/Leaded+Hardtear) acts as a pseudo-hyperarmor buff that prevents stagger from certain damage levels for 10 seconds.
+  - Drops from Ulcerated Tree Spirit in Mt. Gelmir.
+- [Speckled Hardtear](https://eldenring.wiki.fextralife.com/Speckled+Hardtear) temporarily raises all resistances and heals all status ailments.
+  - Defeat Wormface at Minor Erdtree (Altus Plateau).
+- [Stonebarb Cracked Tear](https://eldenring.wiki.fextralife.com/Stonebarb+Cracked+Tear) makes one's attacks more likely to break an enemy's stance.
+  - Obtained by defeating the Putrid Avatar near the second Minor Erdtree in Caelid.


### PR DESCRIPTION
Seamless co-op mod build for Rock James the Colossal Crusher. Copied from the Bushido Black Flame Build (150) and adjusted accordingly.